### PR TITLE
refactor: drop disconnected socket client

### DIFF
--- a/StreamIt/StreamingSession.swift
+++ b/StreamIt/StreamingSession.swift
@@ -75,7 +75,7 @@ class StreamingSession {
                     self.headersSent = true
                     self.client.write(headersData, withTimeout: -1, tag: 0)
                 } else {
-                    if self.client.connectedPort.hashValue == 0 {
+                    if (self.client.connectedPort.hashValue == 0 || !self.client.isConnected) {
                         // y a personne en face ... on arrête d'envoyer des données
                         self.close()
                         print("Dropping client [#\(self.id)]")


### PR DESCRIPTION
Only write data to connected socket clients.
This fixes the bug that if you refresh a stream for like 5 times, the stream wouldn't work anymore.